### PR TITLE
Cron job updates

### DIFF
--- a/packages/server/src/redisConn.ts
+++ b/packages/server/src/redisConn.ts
@@ -11,11 +11,15 @@ export const PORT = Number(split[1]);
 let redisClient: RedisClientType;
 
 const createRedisClient = async () => {
+    console.log('creating redis client...')
     const url = `redis://${HOST}:${PORT}`;
-    logger.log(LogLevel.info, 'Creating Redis client', { code: genErrorCode('0184'), url });
+    logger.log(LogLevel.info, 'Creating Redis client.', { code: genErrorCode('0184'), url });
     const redisClient = createClient({ url });
     redisClient.on('error', (error) => {
         logger.log(LogLevel.error, 'Error occured while connecting or accessing redis server', { code: genErrorCode('0002'), error });
+    });
+    redisClient.on('end', () => {
+        logger.log(LogLevel.info, 'Redis client closed.', { code: genErrorCode('0208'), url });
     });
     await redisClient.connect();
     return redisClient;

--- a/packages/server/src/statsLog.ts
+++ b/packages/server/src/statsLog.ts
@@ -26,13 +26,22 @@ import { StatAllTime, StatDay, StatMonth, StatWeek, StatYear } from './models';
 import { genErrorCode, logger, LogLevel } from './logger';
 const { PrismaClient } = pkg;
 
-// Daily triggered every 15 minutes
+// Cron syntax created using this website: https://crontab.guru/
+/**
+ * Daily cron, triggered every 15 minutes to give us 96 data points
+ */
 const dailyCron = '*/15 * * * *';
-// Weekly triggered every hour
+/**
+ * Weekly triggered every hour, to give us 168 data points
+ */
 const weeklyCron = '0 * * * *';
-// Monthly triggered 4 times per day
+/**
+ * Monthly triggered 4 times per day, to give us ~120 data points
+ */
 const monthlyCron = '0 0 4 * *';
-// Yearly (and all-time) triggered once per day
+/**
+ * Yearly (and all-time) triggered once per day
+ */
 const yearlyCron = '0 0 * * *';
 
 /**
@@ -261,6 +270,7 @@ async function calculateStats(timeInterval: StatTimeInterval): Promise<{ [key in
             // [StatType.RoutinesCompletedTimeAverage]: await calculateRoutinesCompletedTimeAverage(timeInterval, prisma),
             [StatType.Standards]: await calculateStandards(timeInterval, prisma),
         }
+        prisma.$disconnect();
     } catch (error) {
         logger.log(LogLevel.error, 'Caught error calculating stats', { code: genErrorCode('0000'), error });
     } finally {
@@ -316,6 +326,7 @@ async function logStats(timeInterval: StatTimeInterval) {
  * See https://crontab.guru/ for more information on cron jobs.
  */
 export const initStatsCronJobs = () => {
+    logger.log(LogLevel.info, 'Initializing stats cron jobs.', { code: genErrorCode('0209') });
     // Daily
     cron.schedule(dailyCron, () => {
         console.log('daily start')


### PR DESCRIPTION
I realized that the real performance issue may not stem from redis, but from the cron jobs. According to the prisma docs (https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/connection-management#calling-disconnect-explicitly), prisma.$dicsonnect() should probably be called when using a cron job. So that's what I'm trying now.